### PR TITLE
correct clustering bug

### DIFF
--- a/deeprank_gnn/NeuralNet.py
+++ b/deeprank_gnn/NeuralNet.py
@@ -134,7 +134,7 @@ class NeuralNet(object):
         # dataset
         dataset = HDF5DataSet(root='./', database=database, index=self.index,
                               node_feature=self.node_feature, edge_feature=self.edge_feature,
-                              target=self.target)
+                              target=self.target, clustering_method=self.cluster_nodes)
 
         if self.cluster_nodes != None:
             if self.cluster_nodes == 'mcl' or self.cluster_nodes == 'louvain':


### PR DESCRIPTION
Answer to issue [#58](https://github.com/DeepRank/Deeprank-GNN/issues/58) 

**Issue**: when running Deeprank-GNN with the **louvain** node clustering algorithm, Deeprank-GNN was still expecting **mcl** cluster data due to a lack of specification of the clustering algorithm used when loading the data (in `HDF5dataset`)

**Answer**: Update every call of HDF5dataset with clustering information


```
HDF5DataSet(root='./', database=database, node_feature=self.node_feature, edge_feature=self.edge_feature,
                  target=self.target, clustering_method=self.cluster_nodes)
```